### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade --allow-unsafe -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/django.txt requirements/django.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.1.3
     # via -r requirements/base.in
-jinja2==3.0.3
+jinja2==3.1.2
     # via -r requirements/base.in
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
-pbr==5.8.1
+pbr==5.9.0
     # via stevedore
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via -r requirements/base.in
 pyyaml==6.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.3.1
+coverage==6.4.1
     # via codecov
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
@@ -22,15 +22,15 @@ idna==3.3
     # via requests
 packaging==21.3
     # via tox
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-requests==2.27.1
+requests==2.28.0
     # via codecov
 six==1.16.0
     # via
@@ -38,13 +38,13 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.5
+tox==3.25.0
     # via
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.8
+urllib3==1.26.9
     # via requests
-virtualenv==20.13.1
+virtualenv==20.15.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.9.3
+astroid==2.11.6
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -17,17 +17,17 @@ attrs==21.4.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   -r requirements/ci.txt
     #   requests
-chardet==4.0.0
+chardet==5.0.0
     # via diff-cover
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via
     #   -r requirements/ci.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -35,35 +35,39 @@ click==8.0.3
     #   code-annotations
     #   edx-lint
     #   pip-tools
-click-log==0.3.2
+click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.3.1
+coverage[toml]==6.4.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-diff-cover==6.4.4
+diff-cover==6.5.1
     # via -r requirements/dev.in
+dill==0.3.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   pylint
 distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.12
+django==3.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
-edx-lint==5.2.1
+edx-lint==5.2.4
     # via -r requirements/quality.txt
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -80,7 +84,7 @@ isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -89,11 +93,11 @@ lazy-object-proxy==1.7.1
     # via
     #   -r requirements/quality.txt
     #   astroid
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/quality.txt
     #   jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -105,7 +109,7 @@ packaging==21.3
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pbr==5.8.1
+pbr==5.9.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
@@ -113,9 +117,9 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.5.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.txt
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -138,9 +142,9 @@ pycodestyle==2.8.0
     # via -r requirements/quality.txt
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
-pygments==2.11.2
+pygments==2.12.0
     # via diff-cover
-pylint==2.12.2
+pylint==2.14.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -151,7 +155,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -160,22 +164,22 @@ pylint-plugin-utils==0.7
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   packaging
-pytest==7.0.0
+pytest==7.1.2
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/quality.txt
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/quality.txt
     #   django
@@ -183,7 +187,7 @@ pyyaml==6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-requests==2.27.1
+requests==2.28.0
     # via
     #   -r requirements/ci.txt
     #   codecov
@@ -213,32 +217,35 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-    #   pylint
     #   tox
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   coverage
     #   pep517
+    #   pylint
     #   pytest
-tox==3.24.5
+tomlkit==0.11.0
+    # via
+    #   -r requirements/quality.txt
+    #   pylint
+tox==3.25.0
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-typing-extensions==4.0.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/ci.txt
     #   requests
-virtualenv==20.13.1
+virtualenv==20.15.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -246,7 +253,7 @@ wheel==0.37.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.13.3
+wrapt==1.14.1
     # via
     #   -r requirements/quality.txt
     #   astroid

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
-django==3.2.12
+django==3.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/django.in
-pytz==2021.3
+pytz==2022.1
     # via django
 sqlparse==0.4.2
     # via django

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -5,5 +5,5 @@
 
 doc8                      # reStructuredText style checker
 edx_sphinx_theme          # edX theme for Sphinx output
-readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
+twine                     # Validates README.rst for usage on PyPI

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -14,27 +14,29 @@ attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.9.1
+babel==2.10.3
     # via sphinx
-bleach==4.1.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via requests
-click==8.0.3
+click==8.1.3
     # via -r requirements/test.txt
-coverage[toml]==6.3.1
+commonmark==0.9.1
+    # via rich
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-django==3.2.12
+django==3.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-doc8==0.10.1
+doc8==0.11.2
     # via -r requirements/doc.in
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   doc8
     #   readme-renderer
@@ -46,17 +48,22 @@ idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.10.1
-    # via sphinx
+importlib-metadata==4.12.0
+    # via
+    #   keyring
+    #   sphinx
+    #   twine
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   sphinx
-markupsafe==2.0.1
+keyring==23.6.0
+    # via twine
+markupsafe==2.1.1
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -65,13 +72,14 @@ mock==4.0.3
 packaging==21.3
     # via
     #   -r requirements/test.txt
-    #   bleach
     #   pytest
     #   sphinx
-pbr==5.8.1
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
+pkginfo==1.8.3
+    # via twine
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
@@ -80,43 +88,53 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   doc8
     #   readme-renderer
+    #   rich
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==7.0.0
+pytest==7.1.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via -r requirements/test.txt
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/test.txt
     #   babel
     #   django
 pyyaml==6.0
     # via -r requirements/test.txt
-readme-renderer==32.0
-    # via -r requirements/doc.in
-requests==2.27.1
-    # via sphinx
-restructuredtext-lint==1.3.2
+readme-renderer==35.0
+    # via twine
+requests==2.28.0
+    # via
+    #   requests-toolbelt
+    #   sphinx
+    #   twine
+requests-toolbelt==0.9.1
+    # via twine
+restructuredtext-lint==1.4.0
     # via doc8
+rfc3986==2.0.0
+    # via twine
+rich==12.4.4
+    # via twine
 six==1.16.0
     # via
     #   bleach
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.4.0
+sphinx==5.0.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -144,14 +162,20 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
     #   pytest
-urllib3==1.26.8
-    # via requests
+twine==4.0.1
+    # via -r requirements/doc.in
+typing-extensions==4.2.0
+    # via rich
+urllib3==1.26.9
+    # via
+    #   requests
+    #   twine
 webencodings==0.5.1
     # via bleach
-zipp==3.7.0
+zipp==3.8.0
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.5.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
-tomli==2.0.0
+tomli==2.0.1
     # via pep517
 wheel==0.37.1
     # via pip-tools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.3
+pip==22.1.2
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.9.3
+astroid==2.11.6
     # via
     #   pylint
     #   pylint-celery
@@ -16,25 +16,27 @@ attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-lint
-click-log==0.3.2
+click-log==0.4.0
     # via edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==6.3.1
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-django==3.2.12
+dill==0.3.5.1
+    # via pylint
+django==3.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-edx-lint==5.2.1
+edx-lint==5.2.4
     # via -r requirements/quality.in
 iniconfig==1.1.1
     # via
@@ -44,17 +46,17 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
 lazy-object-proxy==1.7.1
     # via astroid
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/test.txt
     #   jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
@@ -62,11 +64,11 @@ packaging==21.3
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.8.1
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via
@@ -80,7 +82,7 @@ pycodestyle==2.8.0
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pylint==2.12.2
+pylint==2.14.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -88,27 +90,27 @@ pylint==2.12.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.3
     # via edx-lint
 pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==7.0.0
+pytest==7.1.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -132,18 +134,19 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-toml==0.10.2
-    # via pylint
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
+    #   pylint
     #   pytest
-typing-extensions==4.0.1
+tomlkit==0.11.0
+    # via pylint
+typing-extensions==4.2.0
     # via
     #   astroid
     #   pylint
-wrapt==1.13.3
+wrapt==1.14.1
     # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,24 +4,24 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/django.txt
     #   django
 attrs==21.4.0
     # via pytest
-click==8.0.3
+click==8.1.3
     # via -r requirements/base.txt
-coverage[toml]==6.3.1
+coverage[toml]==6.4.1
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/django.txt
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.3
+jinja2==3.1.2
     # via -r requirements/base.txt
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -29,7 +29,7 @@ mock==4.0.3
     # via -r requirements/test.in
 packaging==21.3
     # via pytest
-pbr==5.8.1
+pbr==5.9.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -37,15 +37,15 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==7.0.0
+pytest==7.1.2
     # via pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/test.in
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via -r requirements/base.txt
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/django.txt
     #   django
@@ -61,7 +61,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   coverage
     #   pytest

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
     version=VERSION,
     description="""Extensible tools for parsing annotations in codebases""",
     long_description=README + '\n\n' + CHANGELOG,
+    long_description_content_type='text/x-rst',
     author='edX',
     author_email='oscm@edx.org',
     url='https://github.com/edx/code-annotations',

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ setenv =
 whitelist_externals = 
     make
     rm
+    twine
 deps = 
     -r{toxinidir}/requirements/doc.txt
 commands = 
@@ -37,7 +38,8 @@ commands =
     rm -f docs/modules.rst
     make -C docs clean
     make -C docs html
-    python setup.py check --restructuredtext --strict
+    python setup.py bdist_wheel
+    twine check dist/*
 
 [testenv:quality]
 whitelist_externals = 


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA:https://2u-internal.atlassian.net/browse/BOM-3456