### PR TITLE
fix: redner optional toggle fields when exists

### DIFF
--- a/code_annotations/contrib/sphinx/extensions/featuretoggles.py
+++ b/code_annotations/contrib/sphinx/extensions/featuretoggles.py
@@ -74,8 +74,10 @@ class FeatureToggles(SphinxDirective):
             toggle_default_value = toggle.get(".. toggle_default:", "Not defined")
             toggle_default_node = nodes.literal(text=quote_value(toggle_default_value))
             toggle_section = nodes.section("", ids=[f"featuretoggle-{toggle_name}"])
-            toggle_section += nodes.title(text=toggle_name)
-            toggle_section += nodes.paragraph("", "Default: ", toggle_default_node)
+            toggle_section += nodes.title(text=toggle_name, ids="name")
+            toggle_section += nodes.paragraph(
+                "", "Default: ", toggle_default_node, ids="default"
+            )
             toggle_section += nodes.paragraph(
                 "",
                 "Source: ",
@@ -90,14 +92,28 @@ class FeatureToggles(SphinxDirective):
                         toggle["line_number"],
                     ),
                 ),
+                ids="source",
             )
             toggle_section += nodes.paragraph(
-                text=toggle.get(".. toggle_description:", "")
+                text=f'Desc: {toggle.get(".. toggle_description:", "NaN")}',
+                ids="description",
             )
             if toggle.get(".. toggle_warning:") not in (None, "None", "n/a", "N/A"):
                 toggle_section += nodes.warning(
-                    "", nodes.paragraph("", toggle[".. toggle_warning:"])
+                    "", nodes.paragraph("", toggle[".. toggle_warning:"]), ids="warning"
                 )
+            optional_attrs = [
+                "creation_date",
+                "target_removal_date",
+                "implementation",
+                "use_cases",
+            ]
+            for opt in optional_attrs:
+                if toggle.get(f".. toggle_{opt}:") not in (None, "None", "n/a", "N/A"):
+                    toggle_section += nodes.paragraph(
+                        text=f'{opt.title().replace("_"," ")}: {toggle[f".. toggle_{opt}:"]}',
+                        ids=opt,
+                    )
             yield toggle_section
 
 

--- a/code_annotations/contrib/sphinx/extensions/featuretoggles.py
+++ b/code_annotations/contrib/sphinx/extensions/featuretoggles.py
@@ -74,9 +74,9 @@ class FeatureToggles(SphinxDirective):
             toggle_default_value = toggle.get(".. toggle_default:", "Not defined")
             toggle_default_node = nodes.literal(text=quote_value(toggle_default_value))
             toggle_section = nodes.section("", ids=[f"featuretoggle-{toggle_name}"])
-            toggle_section += nodes.title(text=toggle_name, ids="name")
+            toggle_section += nodes.title(text=toggle_name, ids=[f"name-{toggle_name}"])
             toggle_section += nodes.paragraph(
-                "", "Default: ", toggle_default_node, ids="default"
+                "", "Default: ", toggle_default_node, ids=[f"default-{toggle_name}"]
             )
             toggle_section += nodes.paragraph(
                 "",
@@ -92,15 +92,15 @@ class FeatureToggles(SphinxDirective):
                         toggle["line_number"],
                     ),
                 ),
-                ids="source",
+                ids=[f"source-{toggle_name}"],
             )
             toggle_section += nodes.paragraph(
                 text=f'Desc: {toggle.get(".. toggle_description:", "NaN")}',
-                ids="description",
+                ids=[f"description-{toggle_name}"],
             )
             if toggle.get(".. toggle_warning:") not in (None, "None", "n/a", "N/A"):
                 toggle_section += nodes.warning(
-                    "", nodes.paragraph("", toggle[".. toggle_warning:"]), ids="warning"
+                    "", nodes.paragraph("", toggle[".. toggle_warning:"]), ids=[f"warning-{toggle_name}"]
                 )
             optional_attrs = [
                 "creation_date",
@@ -112,7 +112,7 @@ class FeatureToggles(SphinxDirective):
                 if toggle.get(f".. toggle_{opt}:") not in (None, "None", "n/a", "N/A"):
                     toggle_section += nodes.paragraph(
                         text=f'{opt.title().replace("_"," ")}: {toggle[f".. toggle_{opt}:"]}',
-                        ids=opt,
+                        ids=[f"{opt}-{toggle_name}"],
                     )
             yield toggle_section
 

--- a/code_annotations/contrib/sphinx/extensions/settings.py
+++ b/code_annotations/contrib/sphinx/extensions/settings.py
@@ -86,9 +86,9 @@ class Settings(SphinxDirective):
                 text=quote_value(setting_default_value)
             )
             setting_section = nodes.section("", ids=[f"setting-{setting_name}"])
-            setting_section += nodes.title(text=setting_name, ids="title")
+            setting_section += nodes.title(text=setting_name, ids=[f"title-{setting_name}"])
             setting_section += nodes.paragraph(
-                "", "Default: ", setting_default_node, ids="default"
+                "", "Default: ", setting_default_node, ids=[f"default-{setting_name}"]
             )
             setting_section += nodes.paragraph(
                 "",
@@ -104,17 +104,17 @@ class Settings(SphinxDirective):
                         setting["line_number"],
                     ),
                 ),
-                ids="source",
+                ids=[f"source-{setting_name}"],
             )
             setting_section += nodes.paragraph(
                 text=setting.get(".. setting_description:", ""),
-                ids="description",
+                ids=[f"description-{setting_name}"],
             )
             if setting.get(".. setting_warning:") not in (None, "None", "n/a", "N/A"):
                 setting_section += nodes.warning(
                     "",
                     nodes.paragraph("", setting[".. setting_warning:"]),
-                    ids="warning",
+                    ids=[f"warning-{setting_name}"],
                 )
             yield setting_section
 

--- a/code_annotations/contrib/sphinx/extensions/settings.py
+++ b/code_annotations/contrib/sphinx/extensions/settings.py
@@ -19,7 +19,9 @@ def find_settings(source_path):
     Return:
         settings (dict): Django settings indexed by name.
     """
-    return find_annotations(source_path, SETTING_ANNOTATIONS_CONFIG_PATH, ".. setting_name:")
+    return find_annotations(
+        source_path, SETTING_ANNOTATIONS_CONFIG_PATH, ".. setting_name:"
+    )
 
 
 class Settings(SphinxDirective):
@@ -72,7 +74,9 @@ class Settings(SphinxDirective):
         source_path = os.path.join(self.env.config.settings_source_path, folder_path)
         settings = find_settings(source_path)
         # folder_path can point to a file or directory
-        root_folder = folder_path if os.path.isdir(source_path) else os.path.dirname(folder_path)
+        root_folder = (
+            folder_path if os.path.isdir(source_path) else os.path.dirname(folder_path)
+        )
         for setting_name in sorted(settings):
             setting = settings[setting_name]
             # setting["filename"] is relative to the root_path
@@ -82,8 +86,10 @@ class Settings(SphinxDirective):
                 text=quote_value(setting_default_value)
             )
             setting_section = nodes.section("", ids=[f"setting-{setting_name}"])
-            setting_section += nodes.title(text=setting_name)
-            setting_section += nodes.paragraph("", "Default: ", setting_default_node)
+            setting_section += nodes.title(text=setting_name, ids="title")
+            setting_section += nodes.paragraph(
+                "", "Default: ", setting_default_node, ids="default"
+            )
             setting_section += nodes.paragraph(
                 "",
                 "Source: ",
@@ -98,13 +104,17 @@ class Settings(SphinxDirective):
                         setting["line_number"],
                     ),
                 ),
+                ids="source",
             )
             setting_section += nodes.paragraph(
-                text=setting.get(".. setting_description:", "")
+                text=setting.get(".. setting_description:", ""),
+                ids="description",
             )
             if setting.get(".. setting_warning:") not in (None, "None", "n/a", "N/A"):
                 setting_section += nodes.warning(
-                    "", nodes.paragraph("", setting[".. setting_warning:"])
+                    "",
+                    nodes.paragraph("", setting[".. setting_warning:"]),
+                    ids="warning",
                 )
             yield setting_section
 
@@ -114,7 +124,9 @@ def setup(app):
     Declare the Sphinx extension.
     """
     app.add_config_value(
-        "settings_source_path", os.path.abspath(".."), "env",
+        "settings_source_path",
+        os.path.abspath(".."),
+        "env",
     )
     app.add_config_value("settings_repo_url", "", "env")
     app.add_config_value("settings_repo_version", "master", "env")


### PR DESCRIPTION
  - This commit make it possible to render extra toggle fields
  if they are defiend.

  - It also ids fields for the nodes, in order to be easily
   extact these fields.
Please look at photo below to see the different, notice the new extra fields added. 


### Before: Check online [ref](https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-BLOCK_STRUCTURES_SETTINGS['PRUNING_ACTIVE'])
<img width="761" alt="Screen Shot 2022-08-17 at 13 52 43" src="https://user-images.githubusercontent.com/16361375/185101438-f6a25bba-5c83-4303-8cea-06281bf3e18d.png">

### After: 
<img width="857" alt="Screen Shot 2022-08-17 at 13 51 38" src="https://user-images.githubusercontent.com/16361375/185101321-070e22e7-83c1-488b-abb7-8c71ab4e582e.png">

