### PR TITLE
fix: Fix timestamp handling (elapsed; formatting)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+[1.8.1] - 2024-07-11
+~~~~~~~~~~~~~~~~~~~~
+
+* Fix elapsed-time calculations to always use UTC. Other clocks can be altered partway through by Django config settings being loaded while the timer is running, resulting in reporting elapsed time of "-17999.895582 seconds" or similar.
+* Fix report filename to use year-month-day order, not year-day-month. (Also more compact, now.)
+
 [1.8.0] - 2024-03-31
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -2,4 +2,4 @@
 Extensible tools for parsing annotations in codebases.
 """
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'

--- a/code_annotations/base.py
+++ b/code_annotations/base.py
@@ -616,9 +616,9 @@ class BaseSearch(metaclass=ABCMeta):
         """
         self.echo.echo_vv(yaml.dump(all_results, default_flow_style=False))
 
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         report_filename = os.path.join(self.config.report_path, '{}{}.yaml'.format(
-            report_prefix, now.strftime('%Y-%d-%m-%H-%M-%S')
+            report_prefix, now.strftime('%Y%m%d-%H%M%S')
         ))
 
         formatted_results = self._format_results_for_report(all_results)

--- a/code_annotations/cli.py
+++ b/code_annotations/cli.py
@@ -61,7 +61,7 @@ def django_find_annotations(
     Subcommand for dealing with annotations in Django models.
     """
     try:
-        start_time = datetime.datetime.now()
+        start_time = datetime.datetime.utcnow()
         config = AnnotationConfig(config_file, report_path, verbosity)
         searcher = DjangoSearch(config)
 
@@ -106,7 +106,7 @@ def django_find_annotations(
             for filename in annotated_models:
                 annotation_count += len(annotated_models[filename])
 
-            elapsed = datetime.datetime.now() - start_time
+            elapsed = datetime.datetime.utcnow() - start_time
             click.echo("Search found {} annotations in {} seconds.".format(
                 annotation_count, elapsed.total_seconds()
             ))
@@ -137,7 +137,7 @@ def static_find_annotations(config_file, source_path, report_path, verbosity, li
     Subcommand to find annotations via static file analysis.
     """
     try:
-        start_time = datetime.datetime.now()
+        start_time = datetime.datetime.utcnow()
         config = AnnotationConfig(config_file, report_path, verbosity, source_path)
         searcher = StaticSearch(config)
         all_results = searcher.search()
@@ -161,7 +161,7 @@ def static_find_annotations(config_file, source_path, report_path, verbosity, li
             report_filename = searcher.report(all_results)
             click.echo(f"Report written to {report_filename}.")
 
-        elapsed = datetime.datetime.now() - start_time
+        elapsed = datetime.datetime.utcnow() - start_time
         annotation_count = 0
 
         for filename in all_results:
@@ -191,7 +191,7 @@ def generate_docs(
     """
     Generate documentation from a code annotations report.
     """
-    start_time = datetime.datetime.now()
+    start_time = datetime.datetime.utcnow()
 
     try:
         config = AnnotationConfig(config_file, verbosity)
@@ -210,7 +210,7 @@ def generate_docs(
         renderer = ReportRenderer(config, report_files)
         renderer.render()
 
-        elapsed = datetime.datetime.now() - start_time
+        elapsed = datetime.datetime.utcnow() - start_time
         click.echo(f"Report rendered in {elapsed.total_seconds()} seconds.")
     except Exception as exc:
         click.echo(traceback.print_exc())

--- a/code_annotations/generate_docs.py
+++ b/code_annotations/generate_docs.py
@@ -27,7 +27,7 @@ class ReportRenderer:
         self.config = config
         self.echo = self.config.echo
         self.report_files = report_files
-        self.create_time = datetime.datetime.now().isoformat()
+        self.create_time = datetime.datetime.utcnow().isoformat()
 
         self.full_report = self._aggregate_reports()
 


### PR DESCRIPTION
- Use `utcnow()` instead of `now()` for elapsed time, because the `now()` clock can easily change. I was getting "Search found 8 annotations in -17999.895582 seconds." from some runs of pii_check, and I narrowed it down to `DjangoSearch(config)` changing the clock. Presumably something is hardcoding Eastern Standard Time somewhere. (It's EDT right now!) There might be a better timer utility somewhere, but this should at least be correct when leap seconds and NTP updates aren't involved. :-)
- Make the timestamp in the report filename go year-month-day rather than year-day-month. Also make it more compact while I'm in there.

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
