### PR TITLE
feat: add support for optional event warning for in-line annotation

### DIFF
--- a/code_annotations/contrib/config/openedx_events_annotations.yaml
+++ b/code_annotations/contrib/config/openedx_events_annotations.yaml
@@ -12,6 +12,7 @@ annotations:
     - ".. event_description:":
     - ".. event_data:":
     - ".. event_key_field:":
+    - ".. event_warning:":
 extensions:
     python:
         - py

--- a/code_annotations/contrib/config/openedx_events_annotations.yaml
+++ b/code_annotations/contrib/config/openedx_events_annotations.yaml
@@ -6,7 +6,7 @@ safelist_path: .annotation_safe_list.yml
 coverage_target: 100.0
 annotations:
   feature_toggle:
-    # See annotation format documentation: https://edx-toggles.readthedocs.io/en/latest/how_to/documenting_new_feature_toggles.html
+    # See annotation format documentation: https://docs.openedx.org/projects/openedx-events/en/latest/reference/in-line-code-annotations-for-an-event.html
     - ".. event_type:":
     - ".. event_name:":
     - ".. event_description:":

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -118,6 +118,11 @@ class OpenedxEvents(SphinxDirective):
                      f" {event['line_number']})"
             )
 
+            if event.get(".. event_warning:") not in (None, "None", "n/a", "N/A"):
+                event_section += nodes.warning(
+                    "", nodes.paragraph("", event[".. event_warning:"]), ids=[f"warning-{event_name}"]
+                )
+
             subject_header += event_section
 
         if domain_header:


### PR DESCRIPTION
## Description

Add warning for openedx-events annotations so developers can include relevant information about the current event. As for now, these warnings have been used to indicate that the event at the time of implementation doesn't have for the event bus.

## Testing Instructions
1. Create a venv 
2. Install this version of openedx-events which uses `.. event_warning` instead of a `Warning: ` label.
3. Generate docs for openedx-events by running: `make docs`

Here's the expected output:
![image](https://github.com/user-attachments/assets/5f9aed6b-eeef-4aee-bcdb-2aa2db698b96)
