### PR TITLE
chore: Loosen requirement constraints

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.5.0
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
@@ -11,18 +17,18 @@ filelock==3.16.1
     #   tox
     #   virtualenv
 packaging==24.2
-    # via tox
+    # via
+    #   pyproject-api
+    #   tox
 platformdirs==4.3.6
-    # via virtualenv
+    # via
+    #   tox
+    #   virtualenv
 pluggy==1.5.0
     # via tox
-py==1.11.0
+pyproject-api==1.8.0
     # via tox
-six==1.17.0
-    # via tox
-tox==3.28.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/ci.in
+tox==4.23.2
+    # via -r requirements/ci.in
 virtualenv==20.28.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,9 +10,3 @@
 
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0
-
-# Temporary to Support the python 3.11 Upgrade
-backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,8 +17,15 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+cachetools==5.5.0
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 chardet==5.2.0
-    # via diff-cover
+    # via
+    #   -r requirements/ci.txt
+    #   diff-cover
+    #   tox
 click==8.1.7
     # via
     #   -r requirements/pip-tools.txt
@@ -35,6 +42,10 @@ code-annotations==2.1.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 coverage[toml]==7.6.9
     # via
     #   -r requirements/quality.txt
@@ -89,6 +100,7 @@ packaging==24.2
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   tox
 pbr==6.1.0
@@ -102,6 +114,7 @@ platformdirs==4.3.6
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
+    #   tox
     #   virtualenv
 pluggy==1.5.0
     # via
@@ -109,10 +122,6 @@ pluggy==1.5.0
     #   -r requirements/quality.txt
     #   diff-cover
     #   pytest
-    #   tox
-py==1.11.0
-    # via
-    #   -r requirements/ci.txt
     #   tox
 pycodestyle==2.12.1
     # via -r requirements/quality.txt
@@ -140,6 +149,10 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
+pyproject-api==1.8.0
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.2.0
     # via
     #   -r requirements/pip-tools.txt
@@ -161,10 +174,8 @@ pyyaml==6.0.2
     #   code-annotations
 six==1.17.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
-    #   tox
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
@@ -185,10 +196,8 @@ tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.28.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/ci.txt
+tox==4.23.2
+    # via -r requirements/ci.txt
 virtualenv==20.28.0
     # via
     #   -r requirements/ci.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,8 +22,6 @@ beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 certifi==2024.12.14
     # via requests
-cffi==1.17.1
-    # via cryptography
 charset-normalizer==3.4.0
     # via requests
 click==8.1.7
@@ -32,8 +30,6 @@ coverage[toml]==7.6.9
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.0
-    # via secretstorage
 django==4.2.17
     # via
     #   -c requirements/common_constraints.txt
@@ -63,10 +59,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via
     #   -r requirements/test.txt
@@ -87,7 +79,7 @@ more-itertools==10.5.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.19
+nh3==0.2.20
     # via readme-renderer
 packaging==24.2
     # via
@@ -105,9 +97,7 @@ pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycparser==2.22
-    # via cffi
-pydata-sphinx-theme==0.16.0
+pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
 pygments==2.18.0
     # via
@@ -142,8 +132,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.9.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/code-annotations/code-annotations/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
 setuptools==75.6.0
     # via -r requirements/pip.in


### PR DESCRIPTION
**Description:** We're no longer supporting Python 3.9 and tox 4 has been around for a long time now, it's in use in edx-platform so should be safe here.

