### PR TITLE
feat: [FC-0074] add support for optional trigger information

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+[2.2.0] - 2025-01-15
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add support for optional Open edX Event trigger in-line annotation.
+
 [2.1.0] - 2024-12-12
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Add support for optional event warning for in-line annotation.
+* Add support for optional Open edX Event warning for in-line annotation.
 
 [2.0.0] - 2024-10-18
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -2,4 +2,4 @@
 Extensible tools for parsing annotations in codebases.
 """
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'

--- a/code_annotations/contrib/config/__init__.py
+++ b/code_annotations/contrib/config/__init__.py
@@ -3,13 +3,13 @@ Expose contrib configuration file paths as Python variables, for use in 3rd-part
 """
 import os
 
-import importlib_resources
+import importlib.resources
 
-FEATURE_TOGGLE_ANNOTATIONS_CONFIG_PATH = importlib_resources.files(
+FEATURE_TOGGLE_ANNOTATIONS_CONFIG_PATH = importlib.resources.files(
     "code_annotations") / os.path.join("contrib", "config", "feature_toggle_annotations.yaml")
 
-SETTING_ANNOTATIONS_CONFIG_PATH = importlib_resources.files(
+SETTING_ANNOTATIONS_CONFIG_PATH = importlib.resources.files(
     "code_annotations") / os.path.join("contrib", "config", "setting_annotations.yaml")
 
-OPENEDX_EVENTS_ANNOTATIONS_CONFIG_PATH = importlib_resources.files(
+OPENEDX_EVENTS_ANNOTATIONS_CONFIG_PATH = importlib.resources.files(
     "code_annotations") / os.path.join("contrib", "config", "openedx_events_annotations.yaml")

--- a/code_annotations/contrib/config/__init__.py
+++ b/code_annotations/contrib/config/__init__.py
@@ -1,9 +1,9 @@
 """
 Expose contrib configuration file paths as Python variables, for use in 3rd-party utilities.
 """
-import os
-
 import importlib.resources
+
+import os
 
 FEATURE_TOGGLE_ANNOTATIONS_CONFIG_PATH = importlib.resources.files(
     "code_annotations") / os.path.join("contrib", "config", "feature_toggle_annotations.yaml")

--- a/code_annotations/contrib/config/__init__.py
+++ b/code_annotations/contrib/config/__init__.py
@@ -2,7 +2,6 @@
 Expose contrib configuration file paths as Python variables, for use in 3rd-party utilities.
 """
 import importlib.resources
-
 import os
 
 FEATURE_TOGGLE_ANNOTATIONS_CONFIG_PATH = importlib.resources.files(

--- a/code_annotations/contrib/config/openedx_events_annotations.yaml
+++ b/code_annotations/contrib/config/openedx_events_annotations.yaml
@@ -13,7 +13,6 @@ annotations:
     - ".. event_data:":
     - ".. event_key_field:":
     - ".. event_trigger_repository:":
-    - ".. event_trigger_path:":
     - ".. event_warning:":
 extensions:
     python:

--- a/code_annotations/contrib/config/openedx_events_annotations.yaml
+++ b/code_annotations/contrib/config/openedx_events_annotations.yaml
@@ -12,6 +12,8 @@ annotations:
     - ".. event_description:":
     - ".. event_data:":
     - ".. event_key_field:":
+    - ".. event_trigger_repository:":
+    - ".. event_trigger:":
     - ".. event_warning:":
 extensions:
     python:

--- a/code_annotations/contrib/config/openedx_events_annotations.yaml
+++ b/code_annotations/contrib/config/openedx_events_annotations.yaml
@@ -13,7 +13,7 @@ annotations:
     - ".. event_data:":
     - ".. event_key_field:":
     - ".. event_trigger_repository:":
-    - ".. event_trigger:":
+    - ".. event_trigger_path:":
     - ".. event_warning:":
 extensions:
     python:

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -100,8 +100,8 @@ class OpenedxEvents(SphinxDirective):
             event_key_field = event.get(".. event_key_field:", "")
             event_key_literal = nodes.literal(text=event_key_field)
             event_description = event[".. event_description:"]
-            event_trigger_repository = event.get(".. event_trigger_repository:", "").split(" ")
-            event_trigger_path = event.get(".. event_trigger_path:", "").split(" ")
+            event_trigger_repository = event.get(".. event_trigger_repository:")
+            event_trigger_path = event.get(".. event_trigger_path:")
 
             event_section = nodes.section("", ids=[f"openedxevent-{event_type}"])
             event_section += nodes.title(text=event_type, ids=[f"title-{event_type}"])
@@ -132,22 +132,25 @@ class OpenedxEvents(SphinxDirective):
                 ids=[f"definition-{event_name}"],
             )
 
-            event_section += nodes.paragraph(text="Triggers", ids=[f"triggers-{event_name}"])
-            triggers_bullet_list = nodes.bullet_list()
-            for repository, path in zip(event_trigger_repository, event_trigger_path):
-                triggers_bullet_list += nodes.list_item(
-                    "",
-                    nodes.paragraph(
+            if event_trigger_path and event_trigger_repository:
+                event_trigger_path = event_trigger_path.split(" ")
+                event_trigger_repository = event_trigger_repository.split(" ")
+                event_section += nodes.paragraph(text="Triggers", ids=[f"triggers-{event_name}"])
+                triggers_bullet_list = nodes.bullet_list()
+                for repository, path in zip(event_trigger_repository, event_trigger_path):
+                    triggers_bullet_list += nodes.list_item(
                         "",
-                        "Path: ",
-                        nodes.reference(
-                            text=path,
-                            refuri=f"https://github.com/search?q=repo:{repository}+{event_name}+path:{path}"
+                        nodes.paragraph(
+                            "",
+                            "Path: ",
+                            nodes.reference(
+                                text=path,
+                                refuri=f"https://github.com/search?q=repo:{repository}+{event_name}+path:{path}"
+                            ),
                         ),
-                    ),
-                )
+                    )
 
-            event_section += triggers_bullet_list
+                event_section += triggers_bullet_list
 
             if event.get(".. event_warning:") not in (None, "None", "n/a", "N/A"):
                 event_section += nodes.warning(

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -101,7 +101,6 @@ class OpenedxEvents(SphinxDirective):
             event_key_literal = nodes.literal(text=event_key_field)
             event_description = event[".. event_description:"]
             event_trigger_repository = event.get(".. event_trigger_repository:")
-            event_trigger_path = event.get(".. event_trigger_path:")
 
             event_section = nodes.section("", ids=[f"openedxevent-{event_type}"])
             event_section += nodes.title(text=event_type, ids=[f"title-{event_type}"])
@@ -132,20 +131,19 @@ class OpenedxEvents(SphinxDirective):
                 ids=[f"definition-{event_name}"],
             )
 
-            if event_trigger_path and event_trigger_repository:
-                event_trigger_path = event_trigger_path.split(" ")
+            if event_trigger_repository:
                 event_trigger_repository = event_trigger_repository.split(" ")
                 event_section += nodes.paragraph(text="Triggers", ids=[f"triggers-{event_name}"])
                 triggers_bullet_list = nodes.bullet_list()
-                for repository, path in zip(event_trigger_repository, event_trigger_path):
+                for repository in event_trigger_repository:
                     triggers_bullet_list += nodes.list_item(
                         "",
                         nodes.paragraph(
                             "",
-                            "Path: ",
+                            "Event triggered by ",
                             nodes.reference(
-                                text=path,
-                                refuri=f"https://github.com/search?q=repo:{repository}+{event_name}+path:{path}"
+                                text=repository,
+                                refuri=f"https://github.com/search?q=repo:{repository}+{event_name}.send_event&type=code",
                             ),
                         ),
                     )

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -137,7 +137,7 @@ class OpenedxEvents(SphinxDirective):
             for repository, path in zip(event_trigger_repository, event_trigger_path):
                 triggers_bullet_list += nodes.list_item(
                     "",
-                    nodes.strong(
+                    nodes.paragraph(
                         "",
                         "Path: ",
                         nodes.reference(

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -133,17 +133,17 @@ class OpenedxEvents(SphinxDirective):
 
             if event_trigger_repository:
                 event_trigger_repository = event_trigger_repository.split(" ")
-                event_section += nodes.paragraph(text="Triggers", ids=[f"triggers-{event_name}"])
+                event_section += nodes.paragraph(text="Triggered by:", ids=[f"triggers-{event_name}"])
                 triggers_bullet_list = nodes.bullet_list()
                 for repository in event_trigger_repository:
+                    search_url = f"https://github.com/search?q=repo:{repository}+{event_name}.send_event&type=code"
                     triggers_bullet_list += nodes.list_item(
                         "",
                         nodes.paragraph(
                             "",
-                            "Event triggered by ",
                             nodes.reference(
                                 text=repository,
-                                refuri=f"https://github.com/search?q=repo:{repository}+{event_name}.send_event&type=code",
+                                refuri=search_url,
                             ),
                         ),
                     )

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -140,6 +140,7 @@ class OpenedxEvents(SphinxDirective):
                         event_trigger_repository, event_name, event_trigger
                     ),
                 ),
+                ids=[f"trigger-{event_name}"],
             )
 
             if event.get(".. event_warning:") not in (None, "None", "n/a", "N/A"):

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -100,6 +100,8 @@ class OpenedxEvents(SphinxDirective):
             event_key_field = event.get(".. event_key_field:", "")
             event_key_literal = nodes.literal(text=event_key_field)
             event_description = event[".. event_description:"]
+            event_trigger_repository = event.get(".. event_trigger_repository:", "")
+            event_trigger = event.get(".. event_trigger:", "")
 
             event_section = nodes.section("", ids=[f"openedxevent-{event_type}"])
             event_section += nodes.title(text=event_type, ids=[f"title-{event_type}"])
@@ -114,8 +116,30 @@ class OpenedxEvents(SphinxDirective):
                 )
             event_section += nodes.paragraph("", "Event data: ", event_data_literal)
             event_section += nodes.paragraph(
-                text=f"Defined at: {event['filename']} (line"
-                     f" {event['line_number']})"
+                "",
+                "Defined at: ",
+                nodes.reference(
+                    text="{} (line {})".format(
+                        event["filename"], event["line_number"]
+                    ),
+                    refuri="{}/blob/{}/{}#L{}".format(
+                        self.env.config.openedxevents_repo_url,
+                        self.env.config.openedxevents_repo_version,
+                        event["filename"],
+                        event["line_number"],
+                    ),
+                ),
+                ids=[f"definition-{event_name}"],
+            )
+            event_section += nodes.paragraph(
+                "",
+                "Triggered by: ",
+                nodes.reference(
+                    text=event_trigger,
+                    refuri="https://github.com/search?q=repo:{}+{}+path:{}".format(
+                        event_trigger_repository, event_name, event_trigger
+                    ),
+                ),
             )
 
             if event.get(".. event_warning:") not in (None, "None", "n/a", "N/A"):

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -141,6 +141,7 @@ class OpenedxEvents(SphinxDirective):
                         "",
                         nodes.paragraph(
                             "",
+                            "",
                             nodes.reference(
                                 text=repository,
                                 refuri=search_url,

--- a/code_annotations/contrib/sphinx/extensions/openedx_events.py
+++ b/code_annotations/contrib/sphinx/extensions/openedx_events.py
@@ -100,8 +100,8 @@ class OpenedxEvents(SphinxDirective):
             event_key_field = event.get(".. event_key_field:", "")
             event_key_literal = nodes.literal(text=event_key_field)
             event_description = event[".. event_description:"]
-            event_trigger_repository = event.get(".. event_trigger_repository:", "")
-            event_trigger = event.get(".. event_trigger:", "")
+            event_trigger_repository = event.get(".. event_trigger_repository:", "").split(" ")
+            event_trigger_path = event.get(".. event_trigger_path:", "").split(" ")
 
             event_section = nodes.section("", ids=[f"openedxevent-{event_type}"])
             event_section += nodes.title(text=event_type, ids=[f"title-{event_type}"])
@@ -131,17 +131,23 @@ class OpenedxEvents(SphinxDirective):
                 ),
                 ids=[f"definition-{event_name}"],
             )
-            event_section += nodes.paragraph(
-                "",
-                "Triggered by: ",
-                nodes.reference(
-                    text=event_trigger,
-                    refuri="https://github.com/search?q=repo:{}+{}+path:{}".format(
-                        event_trigger_repository, event_name, event_trigger
+
+            event_section += nodes.paragraph(text="Triggers", ids=[f"triggers-{event_name}"])
+            triggers_bullet_list = nodes.bullet_list()
+            for repository, path in zip(event_trigger_repository, event_trigger_path):
+                triggers_bullet_list += nodes.list_item(
+                    "",
+                    nodes.strong(
+                        "",
+                        "Path: ",
+                        nodes.reference(
+                            text=path,
+                            refuri=f"https://github.com/search?q=repo:{repository}+{event_name}+path:{path}"
+                        ),
                     ),
-                ),
-                ids=[f"trigger-{event_name}"],
-            )
+                )
+
+            event_section += triggers_bullet_list
 
             if event.get(".. event_warning:") not in (None, "None", "n/a", "N/A"):
                 event_section += nodes.warning(


### PR DESCRIPTION
## Description

Add triggering fields for opened-events annotations so developers can include relevant information about where the event is being triggered by rendering a link that redirects to a GH search with the source file and the event name. 

## Testing Instructions
1. Create a venv 
2. Install [this](https://github.com/openedx/openedx-events/pull/443) version of openedx-events which uses `event_trigger_repository` and `event_trigger_path`
3. Generate docs for openedx-events by running: `make docs`

You can also review the rendered docs here: https://docsopenedxorg--443.org.readthedocs.build/projects/openedx-events/en/443/

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)