### PR TITLE
docs: update edx.rtd links to docs.openedx.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -500,7 +500,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3.12', None),
     'django': ('https://docs.djangoproject.com/en/4.2/', 'https://docs.djangoproject.com/en/4.2/_objects/'),
     'model_utils': ('https://django-model-utils.readthedocs.io/en/latest/', None),
-    'edx_toggles': ('https://edx.readthedocs.io/projects/edx-toggles/en/latest/', None),
+    'edx_toggles': ('https://docs.openedx.org/projects/edx-toggles/en/latest/', None),
 }
 
 

--- a/docs/contrib/how_to/add_new_annotations_and_extracted_docs.rst
+++ b/docs/contrib/how_to/add_new_annotations_and_extracted_docs.rst
@@ -14,7 +14,7 @@ Annotations are a great way to keep documentation close to the code, but also be
 As an example, we have added `feature toggle annotations to the edx-platform codebase`_. A `Readthedocs document with the edx-platform feature toggles`_ has been generated from them.
 
 .. _feature toggle annotations to the edx-platform codebase: https://github.com/openedx/edx-platform/search?q=toggle_name
-.. _Readthedocs document with the edx-platform feature toggles: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html
+.. _Readthedocs document with the edx-platform feature toggles: https://docs.openedx.org/projects/edx-platform/en/latest/references/featuretoggles.html
 
 Add your own annotations and docs
 =================================

--- a/docs/contrib/how_to/documenting_django_settings.rst
+++ b/docs/contrib/how_to/documenting_django_settings.rst
@@ -56,7 +56,7 @@ Additional details
 
 There are a variety of tips in `certain sections of the how-to for documenting feature toggles`_, that are applicable to documenting non-boolean Django settings as well, but are not duplicated in this document. We recommend you get familiar with the applicable subsections of "Additional details" and "Documenting legacy feature toggles" from the feature toggle how-to.
 
-.. _certain sections of the how-to for documenting feature toggles: https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html#additional-details
+.. _certain sections of the how-to for documenting feature toggles: https://docs.openedx.org/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html#additional-details
 
 Additional resources
 ====================


### PR DESCRIPTION
We've moved a lot of documentation to docs.openedx.org, so update the edx.rtd.io links in this repo.
