### PR TITLE
Dropped django 4.2 support. Bumped dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.12"]
-        toxenv: [quality, docs, django42, django52]
+        toxenv: [quality, docs, django52]
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
         run: tox
 
       - name: Run Coverage
-        if: matrix.python-version == '3.12' && matrix.toxenv=='django42'
+        if: matrix.python-version == '3.12' && matrix.toxenv=='django52'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Dropped Django 4.2 support; minimum supported Django version is now 5.2
+
 [2.3.2] - 2026-03-02
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ cachetools==7.0.5
     # via
     #   -r requirements/ci.txt
     #   tox
-chardet==7.2.0
+chardet==7.3.0
     # via diff-cover
 click==8.3.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,8 +20,6 @@ beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
 certifi==2026.2.25
     # via requests
-cffi==2.0.0
-    # via cryptography
 charset-normalizer==3.4.6
     # via requests
 click==8.3.1
@@ -30,8 +28,6 @@ coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.5
-    # via secretstorage
 django==5.2.12
     # via
     #   -c requirements/common_constraints.txt
@@ -61,10 +57,6 @@ jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
@@ -98,8 +90,6 @@ pluggy==1.6.0
     #   -r requirements/test.txt
     #   pytest
     #   pytest-cov
-pycparser==3.0
-    # via cffi
 pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
 pygments==2.19.2
@@ -139,8 +129,6 @@ rich==14.3.3
     # via twine
 roman-numerals==4.1.0
     # via sphinx
-secretstorage==3.5.0
-    # via keyring
 snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.8.3

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     },
     include_package_data=True,
     install_requires=load_requirements("requirements/base.in"),
-    extras_require={"django": ["Django>=4.2"]},
+    extras_require={"django": ["Django>=5.2"]},
     license="Apache Software License 2.0",
     zip_safe=False,
     keywords="edx pii code annotations",
@@ -98,7 +98,6 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Framework :: Django",
-        "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{312}-django{42,52}
+envlist = py{312}-django{52}
 
 [doc8]
 ignore = D001
@@ -17,7 +17,6 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
Dropped django 4.2 support. Bumped dependencies

Issue: https://github.com/openedx/public-engineering/issues/458